### PR TITLE
changing version to release to align with Maven public repo release

### DIFF
--- a/mfp-adapters-spring-integration/pom.xml
+++ b/mfp-adapters-spring-integration/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.mfpdev</groupId>
     <artifactId>mfp-adapters-spring-integration</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 	<packaging>jar</packaging>
 	<name>MobileFirst Adapter Spring Integration extension </name>
 	<description>

--- a/mfp-adapters-swagger-codegen/pom.xml
+++ b/mfp-adapters-swagger-codegen/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.mfpdev</groupId>
   <artifactId>mfp-adapters-swagger-codegen</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>MobileFirst Adapter Swagger-Codegen Extension</name>
   <description>

--- a/samples/factory-customer-adapter/pom.xml
+++ b/samples/factory-customer-adapter/pom.xml
@@ -102,7 +102,7 @@
 		            <dependency>
 						<groupId>com.github.mfpdev</groupId>
 						<artifactId>mfp-adapters-swagger-codegen</artifactId>
-						<version>1.0.0-SNAPSHOT</version>
+						<version>1.0.0</version>
 					</dependency>
 				</dependencies>
 			    <executions>

--- a/samples/my-spring-xml-adapter/pom.xml
+++ b/samples/my-spring-xml-adapter/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>com.github.mfpdev</groupId>
 			<artifactId>mfp-adapters-spring-integration</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>1.0.0</version>
 		</dependency>
 	</dependencies>
 

--- a/samples/spring-customer-adapter/pom.xml
+++ b/samples/spring-customer-adapter/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 		  <groupId>com.github.mfpdev</groupId>
 		  <artifactId>mfp-adapters-spring-integration</artifactId>
-		  <version>1.0.0-SNAPSHOT</version>
+		  <version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
@@ -100,7 +100,7 @@
 		            <dependency>
 						<groupId>com.github.mfpdev</groupId>
 						<artifactId>mfp-adapters-swagger-codegen</artifactId>
-						<version>1.0.0-SNAPSHOT</version>
+						<version>1.0.0</version>
 					</dependency>
 				</dependencies>
 			    <executions>


### PR DESCRIPTION
The spring-integration and swagger-codegen modules are now release on Maven central repo with 1.0.0 release version.  Accordingly the code on git will have to be moved to this version.  
